### PR TITLE
Expose did-fail-provisional-load events to webview. r=mossop

### DIFF
--- a/lib/browser/guest-view-manager.js
+++ b/lib/browser/guest-view-manager.js
@@ -10,6 +10,7 @@ const supportedWebViewEvents = [
   'load-commit',
   'did-finish-load',
   'did-fail-load',
+  'did-fail-provisional-load',
   'did-frame-finish-load',
   'did-start-loading',
   'did-stop-loading',

--- a/lib/renderer/web-view/guest-view-internal.js
+++ b/lib/renderer/web-view/guest-view-internal.js
@@ -9,6 +9,7 @@ var WEB_VIEW_EVENTS = {
   'load-commit': ['url', 'isMainFrame'],
   'did-finish-load': [],
   'did-fail-load': ['errorCode', 'errorDescription', 'validatedURL', 'isMainFrame'],
+  'did-fail-provisional-load': ['errorCode', 'errorDescription', 'validatedURL', 'isMainFrame'],
   'did-frame-finish-load': ['isMainFrame'],
   'did-start-loading': [],
   'did-stop-loading': [],


### PR DESCRIPTION
This exposes the event on the `webview` object, allowing us to handle failures before attempting to load the page, like SSL cert failures
